### PR TITLE
Add WASD and mouse controls with cube walls

### DIFF
--- a/game/player.py
+++ b/game/player.py
@@ -1,20 +1,69 @@
 # player.py
 from panda3d.core import NodePath, Vec3
+from direct.showbase.DirectObject import DirectObject
+from panda3d.core import WindowProperties
 
-class PlayerController:
+
+MOUSE_SENSITIVITY = 0.2
+MOVE_SPEED = 5
+
+class PlayerController(DirectObject):
+    """Simple WASD controller with mouse look."""
+
     def __init__(self):
+        super().__init__()
+
         self.node = NodePath("player")
         self.node.set_pos(1, 1, 0.5)
 
         base.camera.reparent_to(self.node)
         base.camera.set_pos(0, 0, 0)
-        base.camera.look_at(0, 1, 0)
+        base.camera.set_hpr(0, 0, 0)
 
-    def move_forward(self, speed):
-        self.node.set_pos(self.node, Vec3(0, speed, 0))
+        self.key_map = {"w": False, "s": False, "a": False, "d": False}
+        for key in self.key_map:
+            self.accept(key, self.set_key, [key, True])
+            self.accept(f"{key}-up", self.set_key, [key, False])
 
-    def move_right(self, speed):
-        self.node.set_pos(self.node, Vec3(speed, 0, 0))
+        self.props = WindowProperties()
+        self.center = None
+        self.disable_mouse_look()
 
-    def rotate(self, angle_deg):
-        self.node.set_h(self.node.get_h() + angle_deg)
+        taskMgr.add(self.update, "player-update")
+
+    def disable_mouse_look(self):
+        base.disable_mouse()
+        self.props.setCursorHidden(True)
+        base.win.requestProperties(self.props)
+        self.center = (base.win.get_x_size() // 2, base.win.get_y_size() // 2)
+        base.win.movePointer(0, *self.center)
+
+    def set_key(self, key, value):
+        self.key_map[key] = value
+
+    def update(self, task):
+        dt = globalClock.get_dt()
+        speed = MOVE_SPEED * dt
+
+        if self.key_map["w"]:
+            self.node.set_pos(self.node, Vec3(0, speed, 0))
+        if self.key_map["s"]:
+            self.node.set_pos(self.node, Vec3(0, -speed, 0))
+        if self.key_map["a"]:
+            self.node.set_pos(self.node, Vec3(-speed, 0, 0))
+        if self.key_map["d"]:
+            self.node.set_pos(self.node, Vec3(speed, 0, 0))
+
+        if base.mouseWatcherNode.hasMouse():
+            pointer = base.win.get_pointer(0)
+            dx = pointer.get_x() - self.center[0]
+            dy = pointer.get_y() - self.center[1]
+            self.node.set_h(self.node.get_h() - dx * MOUSE_SENSITIVITY)
+            base.camera.set_p(clamp(base.camera.get_p() - dy * MOUSE_SENSITIVITY, -90, 90))
+            base.win.movePointer(0, *self.center)
+
+        return task.cont
+
+
+def clamp(value, min_val, max_val):
+    return max(min_val, min(max_val, value))

--- a/game/player.py
+++ b/game/player.py
@@ -1,4 +1,3 @@
-# player.py
 from panda3d.core import NodePath, Vec3
 from direct.showbase.DirectObject import DirectObject
 from panda3d.core import WindowProperties
@@ -8,13 +7,13 @@ MOUSE_SENSITIVITY = 0.2
 MOVE_SPEED = 5
 
 class PlayerController(DirectObject):
-    """Simple WASD controller with mouse look."""
 
     def __init__(self):
         super().__init__()
 
         self.node = NodePath("player")
         self.node.set_pos(1, 1, 0.5)
+        self.node.set_scale(0.5) 
 
         base.camera.reparent_to(self.node)
         base.camera.set_pos(0, 0, 0)

--- a/game/world.py
+++ b/game/world.py
@@ -48,9 +48,21 @@ class World:
         card.set_hpr(0, 90, 0)
 
     def add_wall(self, x, y):
-        cm = CardMaker('wall')
-        cm.set_frame(-0.5, 0.5, -0.5, 0.5)
-        wall = self.node.attach_new_node(cm.generate())
-        wall.set_texture(self.wall_tex)
-        wall.set_scale(1, 1, TILE_SIZE)
-        wall.set_pos(x, y, TILE_SIZE / 2)
+        cube = self.node.attach_new_node("wall")
+
+        faces = [
+            ((0, 0, 0), (0, 0.5, 0)),    # front
+            ((180, 0, 0), (0, -0.5, 0)),  # back
+            ((90, 0, 0), (-0.5, 0, 0)),   # left
+            ((-90, 0, 0), (0.5, 0, 0)),   # right
+        ]
+        for hpr, offset in faces:
+            cm = CardMaker('side')
+            cm.set_frame(-0.5, 0.5, -0.5, 0.5)
+            face = cube.attach_new_node(cm.generate())
+            face.set_texture(self.wall_tex)
+            face.set_pos(*offset)
+            face.set_hpr(*hpr)
+
+        cube.set_scale(TILE_SIZE)
+        cube.set_pos(x, y, TILE_SIZE / 2)

--- a/game/world.py
+++ b/game/world.py
@@ -2,8 +2,8 @@ import os
 from panda3d.core import (
     TextureStage, Texture, NodePath, CardMaker, LVector3, Filename
 )
-from utils.config import TILE_SIZE
 
+TILE_SIZE = 1.0 
 ASSET_DIR = os.path.join(os.path.dirname(__file__), '..', 'assets')
 
 class World:
@@ -51,10 +51,10 @@ class World:
         cube = self.node.attach_new_node("wall")
 
         faces = [
-            ((0, 0, 0), (0, 0.5, 0)),    # front
-            ((180, 0, 0), (0, -0.5, 0)),  # back
-            ((90, 0, 0), (-0.5, 0, 0)),   # left
-            ((-90, 0, 0), (0.5, 0, 0)),   # right
+            ((0, 0, 0), (0, 0.5, 0)),      # front
+            ((180, 0, 0), (0, -0.5, 0)),   # back
+            ((90, 0, 0), (-0.5, 0, 0)),    # left
+            ((-90, 0, 0), (0.5, 0, 0)),    # right
         ]
         for hpr, offset in faces:
             cm = CardMaker('side')
@@ -63,6 +63,7 @@ class World:
             face.set_texture(self.wall_tex)
             face.set_pos(*offset)
             face.set_hpr(*hpr)
+            face.set_two_sided(True) 
 
         cube.set_scale(TILE_SIZE)
         cube.set_pos(x, y, TILE_SIZE / 2)

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 from direct.showbase.ShowBase import ShowBase
 from game.world import World
+from game.player import PlayerController
 from utils.maze_gen import generate_maze
 
 class PyMazeApp(ShowBase):
@@ -10,9 +11,8 @@ class PyMazeApp(ShowBase):
         world = World(maze)
         world.node.reparent_to(self.render)
 
-        self.disable_mouse()
-        self.camera.set_pos(1, 1, 0.5)
-        self.camera.look_at(1, 2, 0.5)
+        self.player = PlayerController()
+        self.player.node.reparent_to(self.render)
 
 app = PyMazeApp()
 app.run()

--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ class PyMazeApp(ShowBase):
     def __init__(self):
         super().__init__()
 
-        maze = generate_maze(11, 11)
+        maze = generate_maze(32, 17)
         world = World(maze)
         world.node.reparent_to(self.render)
 


### PR DESCRIPTION
## Summary
- add simple WASD player controller with mouse look
- create cube shaped walls rather than single cards
- hook player controller into the app

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861385f66848325979891d80a732038