### PR TITLE
Attach player node to scene

### DIFF
--- a/game/player.py
+++ b/game/player.py
@@ -13,7 +13,13 @@ class PlayerController(DirectObject):
 
         self.node = NodePath("player")
         self.node.set_pos(1, 1, 0.5)
-        self.node.set_scale(0.5) 
+        self.node.set_scale(0.5)
+        # Attach the player node to the scene graph so the
+        # camera (which will be parented to this node) is part
+        # of the world. Without this the view remains grey and
+        # none of the input works because the camera is not
+        # rendering any objects.
+        self.node.reparent_to(render)
 
         base.camera.reparent_to(self.node)
         base.camera.set_pos(0, 0, 0)


### PR DESCRIPTION
## Summary
- fix player initialization so camera is part of the scene

## Testing
- `python3 -m py_compile game/player.py`
- `python3 -m py_compile main.py game/world.py utils/maze_gen.py utils/config.py`


------
https://chatgpt.com/codex/tasks/task_e_6861acf0e5cc8325ab346ec8a640f0ab